### PR TITLE
fix: pipelined rendering race condition

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -99,6 +99,7 @@ pub struct ImportedDmatexs(Arc<Mutex<HashMap<Handle<Image>, DmaImage>>>);
 enum DmaImage {
     UnImported(Dmatex, DropCallback, DmatexUsage),
     Imported(ImportedTexture),
+    Applied(ImportedTexture),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -244,7 +245,7 @@ fn memory_barrier(
                 .iter()
                 .filter_map(|v| match v.1 {
                     DmaImage::UnImported(_, _, _) => None,
-                    DmaImage::Imported(imported_texture) => Some(imported_texture),
+                    DmaImage::Imported(tex) | DmaImage::Applied(tex) => Some(tex),
                 })
                 .filter_map(|i| {
                     i.texture
@@ -364,6 +365,9 @@ fn insert_dmatex_into_gpu_images(
     for handle in handles {
         // filter out outdated dmatexs
         if gpu_images.get(&handle).is_none() {
+            if matches!(imported.get(&handle), Some(DmaImage::Applied(_))) {
+                imported.remove(&handle);
+            }
             continue;
         }
         if matches!(imported.get(&handle), Some(DmaImage::UnImported(_, _, _)))
@@ -385,7 +389,7 @@ fn insert_dmatex_into_gpu_images(
             continue;
         };
 
-        if let Some(DmaImage::Imported(tex)) = imported.get(&handle) {
+        if let Some(DmaImage::Imported(tex) | DmaImage::Applied(tex)) = imported.get(&handle) {
             debug!("setting texture view!");
             render_tex.texture_view = tex.texture_view.clone();
             render_tex.size = tex.texture.size();
@@ -393,6 +397,9 @@ fn insert_dmatex_into_gpu_images(
             render_tex.texture = tex.texture.clone();
         } else {
             error!("unreachable");
+        }
+        if let Some(DmaImage::Imported(tex)) = imported.remove(&handle) {
+            imported.insert(handle, DmaImage::Applied(tex));
         }
     }
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -364,7 +364,6 @@ fn insert_dmatex_into_gpu_images(
     for handle in handles {
         // filter out outdated dmatexs
         if gpu_images.get(&handle).is_none() {
-            imported.remove(&handle);
             continue;
         }
         if matches!(imported.get(&handle), Some(DmaImage::UnImported(_, _, _)))


### PR DESCRIPTION
With pipelined rendering the render world can run one frame behind the main/app world. When a new DmaImage is inserted into ImportedDmatexes by the main world, the corresponding GpuImage may not exist yet in RenderAssets<GpuImage> because prepare_assets::<GpuImage> may not have processed the extracted Image asset. So gpu_images.get(&handle) is none for both brand new/not yet extracted as genuinely stale, owner dropped cases.

I can consistently reproduce this issue in Stardust by having a startup script with:
```bash
#!/bin/bash

xwayland-satellite :10 &
export DISPLAY=:10
sleep 0.1;

flatland &
atmosphere show the_grid &
gravity -- -0.2 0.0 -0.5 alacritty &
```
After startup the alacritty texture does not show up. Only after resizing the DMA buffer is updated and it works correctly from that point on. If I disable pipelined rendering the texture does show up correctly from the start.

To handle this correctly while still cleaning up ImportedDmatexs I keep track if the GpuImage has already been applied. If it is not applied yet, skip and wait for extraction. If it has been applied, it is removed.