### PR TITLE
Allow specifying extensions for device creation

### DIFF
--- a/examples/import.rs
+++ b/examples/import.rs
@@ -49,7 +49,7 @@ async fn main() -> AppExit {
     App::new()
         .insert_resource(Receiver(rx.into()))
         .init_resource::<PendingDmatex>()
-        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins).disable::<PipelinedRenderingPlugin>())
+        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins, []).disable::<PipelinedRenderingPlugin>())
         .add_plugins(DmabufImportPlugin)
         .add_systems(Startup, setup)
         .add_systems(PreUpdate, update_tex)

--- a/examples/import_many.rs
+++ b/examples/import_many.rs
@@ -50,7 +50,7 @@ async fn main() -> AppExit {
     App::new()
         .insert_resource(Receiver(rx.into()))
         .init_resource::<Imported>()
-        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins).disable::<PipelinedRenderingPlugin>())
+        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins, []).disable::<PipelinedRenderingPlugin>())
         .add_plugins(DmabufImportPlugin)
         .add_systems(Startup, setup)
         .add_systems(PostUpdate, (update_tex, update))

--- a/examples/import_test.rs
+++ b/examples/import_test.rs
@@ -52,7 +52,7 @@ async fn main() -> AppExit {
     App::new()
         .insert_resource(Receiver(rx.into()))
         .init_resource::<PendingDmatex>()
-        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins).disable::<PipelinedRenderingPlugin>())
+        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins, []).disable::<PipelinedRenderingPlugin>())
         .add_plugins(DmabufImportPlugin)
         .add_systems(Startup, setup)
         .add_systems(PreUpdate, update_tex)

--- a/examples/import_test2.rs
+++ b/examples/import_test2.rs
@@ -59,7 +59,7 @@ async fn main() -> AppExit {
     let mut app = App::new();
     app.insert_resource(Receiver(rx.into()))
         .init_resource::<PendingDmatex>()
-        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins).disable::<PipelinedRenderingPlugin>())
+        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins, []).disable::<PipelinedRenderingPlugin>())
         .add_plugins(DmabufImportPlugin)
         .add_systems(Startup, setup)
         // .add_systems(PreUpdate, update_tex)

--- a/examples/import_test3.rs
+++ b/examples/import_test3.rs
@@ -58,7 +58,7 @@ async fn main() -> AppExit {
         .unwrap();
     let mut app = App::new();
     app.insert_resource(Receiver(rx.into()))
-        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins).disable::<PipelinedRenderingPlugin>())
+        .add_plugins(add_dmabuf_init_plugin(DefaultPlugins, []).disable::<PipelinedRenderingPlugin>())
         .add_plugins(DmabufImportPlugin)
         .add_systems(Startup, setup)
         .add_systems(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@ pub fn required_device_extensions() -> Vec<&'static CStr> {
         ash::ext::external_memory_dma_buf::NAME,
         ash::khr::external_memory_fd::NAME,
         ash::khr::external_memory::NAME,
-        ash::khr::external_semaphore::NAME,
-        ash::khr::external_semaphore_fd::NAME,
         ash::khr::swapchain::NAME,
     ]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub fn required_device_extensions() -> Vec<&'static CStr> {
         ash::ext::external_memory_dma_buf::NAME,
         ash::khr::external_memory_fd::NAME,
         ash::khr::external_memory::NAME,
+        ash::khr::external_semaphore::NAME,
+        ash::khr::external_semaphore_fd::NAME,
         ash::khr::swapchain::NAME,
     ]
 }

--- a/src/wgpu_init.rs
+++ b/src/wgpu_init.rs
@@ -1,17 +1,26 @@
 /// Plugin to init the vulkan session with the required extensions,
 /// probably not needed when using bevy_mod_openxr
-pub struct DmabufWgpuInitPlugin;
+#[derive(Default)]
+pub struct DmabufWgpuInitPlugin {
+    pub additional_device_extensions: Vec<&'static std::ffi::CStr>,
+}
 
-pub fn add_dmabuf_init_plugin<G: PluginGroup>(plugins: G) -> PluginGroupBuilder {
+pub fn add_dmabuf_init_plugin<G: PluginGroup>(
+    plugins: G,
+    additional_device_extensions: impl IntoIterator<Item = &'static std::ffi::CStr>,
+) -> PluginGroupBuilder {
     plugins
         .build()
         .disable::<RenderPlugin>()
-        .add_before::<RenderPlugin>(DmabufWgpuInitPlugin)
+        .add_before::<RenderPlugin>(DmabufWgpuInitPlugin {
+            additional_device_extensions: additional_device_extensions.into_iter().collect(),
+        })
 }
 
 impl Plugin for DmabufWgpuInitPlugin {
     fn build(&self, app: &mut bevy::app::App) {
-        let (device, queue, adapter_info, adapter, instance) = init_graphics().unwrap();
+        let (device, queue, adapter_info, adapter, instance) =
+            init_graphics(&self.additional_device_extensions).unwrap();
         app.add_plugins(RenderPlugin {
             render_creation: RenderCreation::Manual(RenderResources(
                 device.into(),
@@ -47,7 +56,9 @@ const VK_TARGET_VERSION_ASH: u32 = ash::vk::make_api_version(0, 1, 2, 0);
 #[cfg(target_os = "android")]
 const VK_TARGET_VERSION_ASH: u32 = ash::vk::make_api_version(0, 1, 1, 0);
 
-fn init_graphics() -> color_eyre::Result<(
+fn init_graphics(
+    additional_device_extensions: &[&'static std::ffi::CStr],
+) -> color_eyre::Result<(
     wgpu::Device,
     wgpu::Queue,
     wgpu::AdapterInfo,
@@ -71,6 +82,7 @@ fn init_graphics() -> color_eyre::Result<(
         ash::ext::metal_objects::NAME,
     ];
     device_extensions.extend(required_device_extensions());
+    device_extensions.extend(additional_device_extensions);
     device_extensions.dedup();
 
     let vk_instance = unsafe {


### PR DESCRIPTION
`dmatex.rs` in the Stardust server calls `Semaphore::import_fd`, which is backed by `vkImportSemaphoreFdKHR`, which is only available if `VK_KHR_external_semaphore_fd` is set. This PR ensures that the relevant extensions are always requested.

It looks like `bevy_mod_openxr::OxrInitPlugin` requests this as part of its device init, which is probably why this wasn't encountered previously. The force-flatscreen path in Stardust does not use that plugin, which means that flatscreen-created devices did not have this extension set.